### PR TITLE
Fix typo for cryptography dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'donna25519>=0.1.1',
-        'cryptoraphy>=1.4',
+        'cryptography>=1.4',
         'smartyparse>=0.1.0',
     ],
 


### PR DESCRIPTION
Left out a 'g', mate.

@Badg 